### PR TITLE
Features/gitlab custom cert

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "gitlab-cargo-shim"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "arrayvec",

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,7 +29,7 @@ pub struct GitlabConfig {
     #[serde(default = "GitlabConfig::default_token_expiry")]
     pub token_expiry: Duration,
     #[serde(default)]
-    pub ssl_cert : Option<PathBuf>
+    pub ssl_cert : Option<String>
 }
 
 impl GitlabConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,6 +28,8 @@ pub struct GitlabConfig {
     pub admin_token: String,
     #[serde(default = "GitlabConfig::default_token_expiry")]
     pub token_expiry: Duration,
+    #[serde(default)]
+    pub ssl_cert : Option<String>
 }
 
 impl GitlabConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,7 +29,7 @@ pub struct GitlabConfig {
     #[serde(default = "GitlabConfig::default_token_expiry")]
     pub token_expiry: Duration,
     #[serde(default)]
-    pub ssl_cert : Option<String>
+    pub ssl_cert: Option<String>,
 }
 
 impl GitlabConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,7 +29,7 @@ pub struct GitlabConfig {
     #[serde(default = "GitlabConfig::default_token_expiry")]
     pub token_expiry: Duration,
     #[serde(default)]
-    pub ssl_cert : Option<String>
+    pub ssl_cert : Option<PathBuf>
 }
 
 impl GitlabConfig {

--- a/src/providers/gitlab.rs
+++ b/src/providers/gitlab.rs
@@ -31,7 +31,7 @@ impl Gitlab {
 
         let ssl_cert = match &config.ssl_cert {
             Some(cert_path) => {
-                let gitlab_cert_bytes = std::fs::read(&cert_path)?;
+                let gitlab_cert_bytes = std::fs::read(cert_path)?;
                 let gitlab_cert = Certificate::from_pem(&gitlab_cert_bytes)?;
                 client_builder = client_builder.add_root_certificate(gitlab_cert.clone());
                 Some(gitlab_cert)
@@ -65,7 +65,7 @@ impl super::UserProvider for Gitlab {
             // want to use our admin token for this request but still want to use any ssl cert provided.
             let mut client_builder = reqwest::Client::builder();
             if let Some(cert) = &self.ssl_cert {
-                client_builder = client_builder.add_root_certificate(cert.clone())
+                client_builder = client_builder.add_root_certificate(cert.clone());
             }
             let client = client_builder.build();
             let res: GitlabJobResponse = handle_error(

--- a/src/providers/gitlab.rs
+++ b/src/providers/gitlab.rs
@@ -9,7 +9,7 @@ use reqwest::{Certificate, header};
 use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, sync::Arc};
 use time::{Duration, OffsetDateTime};
-use tracing::{info, info_span, instrument, Instrument};
+use tracing::{info_span, instrument, Instrument};
 use url::Url;
 
 pub struct Gitlab {
@@ -30,7 +30,6 @@ impl Gitlab {
             .default_headers(headers);
 
         if let Some(cert_path) = &config.ssl_cert {
-            info!(cert_path,"loading gitlab certificate file");
             let gitlab_cert_bytes = std::fs::read(&cert_path)?;
             let gitlab_cert = Certificate::from_pem(&gitlab_cert_bytes)?;
             client_builder = client_builder.add_root_certificate(gitlab_cert);


### PR DESCRIPTION
Closes #49 

This adds an entry in the `gitlab` config section called `ssl-cert` where users can specify the path to the PEM certificate of their gitlab instance if it is using a self-signed certificate.

example configuration:
```toml
# socket address for the SSH server to listen on
listen-address = "[::]:2222"

# directory in which the generated private keys for the server
# should be stored
state-directory = "/var/lib/gitlab-cargo-shim/keys"

[gitlab]
# the base url of the gitlab instance
uri = "https://my.gitlab.internal"
ssl-cert = "/etc/ssl/certs/my.gitlab.internal.pem"

# a personal access token of an admin with permission to `sudo` as other
# users and create impersonation tokens. `sudo` is used to fetch all the
# packages the user can access, and the impersonation token is returned
# to the user to download packages
admin-token = "foobar"
```