### PR TITLE
New feature: per-group client repository definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 /.idea
 config-private.toml
+cert-private.pem
+/keys/*.pem

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -796,6 +796,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1138,6 +1147,15 @@ checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
 dependencies = [
  "aho-corasick",
  "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
  "regex-syntax",
 ]
 
@@ -1674,9 +1692,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a713421342a5a666b7577783721d3117f1b69a393df803ee17bb73b1e122a59"
 dependencies = [
  "ansi_term",
+ "matchers",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "gitlab-cargo-shim"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "arrayvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ sha1 = "0.10"
 shlex = "1.1"
 time = { version = "0.3", features = ["serde"] }
 tracing = "0.1"
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3"}
 thrussh = "0.33"
 thrussh-keys = "0.21"
 tokio = { version = "1.17", features = ["full"] }
@@ -43,3 +43,7 @@ url = { version = "2.2", features = ["serde"] }
 urlencoding = "2.1"
 ustr = "0.9"
 uuid = { version = "1.1", features = ["v4"] }
+
+[features]
+default=[]
+env-filter = ["tracing-subscriber/env-filter"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,5 +46,4 @@ uuid = { version = "1.1", features = ["v4"] }
 
 [features]
 default=[]
-
 env-filter = ["tracing-subscriber/env-filter"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,4 +46,5 @@ uuid = { version = "1.1", features = ["v4"] }
 
 [features]
 default=[]
+
 env-filter = ["tracing-subscriber/env-filter"]

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,7 +29,7 @@ pub struct GitlabConfig {
     #[serde(default = "GitlabConfig::default_token_expiry")]
     pub token_expiry: Duration,
     #[serde(default)]
-    pub ssl_cert : Option<PathBuf>
+    pub ssl_cert : Option<String>
 }
 
 impl GitlabConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,6 +28,8 @@ pub struct GitlabConfig {
     pub admin_token: String,
     #[serde(default = "GitlabConfig::default_token_expiry")]
     pub token_expiry: Duration,
+    #[serde(default)]
+    pub ssl_cert : Option<String>
 }
 
 impl GitlabConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,7 +29,7 @@ pub struct GitlabConfig {
     #[serde(default = "GitlabConfig::default_token_expiry")]
     pub token_expiry: Duration,
     #[serde(default)]
-    pub ssl_cert : Option<String>
+    pub ssl_cert: Option<String>,
 }
 
 impl GitlabConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,7 +29,7 @@ pub struct GitlabConfig {
     #[serde(default = "GitlabConfig::default_token_expiry")]
     pub token_expiry: Duration,
     #[serde(default)]
-    pub ssl_cert : Option<String>
+    pub ssl_cert : Option<PathBuf>
 }
 
 impl GitlabConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,8 +23,16 @@ pub struct Config {
 
 #[derive(Deserialize)]
 #[serde(rename_all = "kebab-case")]
+pub enum GitlabConfigScope {
+    Project,
+    Group,
+}
+#[derive(Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct GitlabConfig {
     pub uri: Url,
+    #[serde(default = "GitlabConfig::default_scope")]
+    pub scope: GitlabConfigScope,
     pub admin_token: String,
     #[serde(default = "GitlabConfig::default_token_expiry")]
     pub token_expiry: Duration,
@@ -36,6 +44,11 @@ impl GitlabConfig {
     #[must_use]
     const fn default_token_expiry() -> Duration {
         Duration::days(30)
+    }
+
+    #[must_use]
+    const fn default_scope() -> GitlabConfigScope {
+        GitlabConfigScope::Project
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,16 +23,9 @@ pub struct Config {
 
 #[derive(Deserialize)]
 #[serde(rename_all = "kebab-case")]
-pub enum GitlabConfigScope {
-    Project,
-    Group,
-}
-#[derive(Deserialize)]
-#[serde(rename_all = "kebab-case")]
 pub struct GitlabConfig {
     pub uri: Url,
-    #[serde(default = "GitlabConfig::default_scope")]
-    pub scope: GitlabConfigScope,
+
     pub admin_token: String,
     #[serde(default = "GitlabConfig::default_token_expiry")]
     pub token_expiry: Duration,
@@ -44,11 +37,6 @@ impl GitlabConfig {
     #[must_use]
     const fn default_token_expiry() -> Duration {
         Duration::days(30)
-    }
-
-    #[must_use]
-    const fn default_scope() -> GitlabConfigScope {
-        GitlabConfigScope::Project
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ use thrussh::{
 };
 use thrussh_keys::key::PublicKey;
 use tokio_util::{codec::Decoder, codec::Encoder as CodecEncoder};
-use tracing::{debug, error, info, info_span, instrument, Instrument, Span};
+use tracing::{debug, error, info, info_span, instrument, Instrument, Span, trace};
 use uuid::Uuid;
 
 const AGENT: &str = concat!(
@@ -309,6 +309,8 @@ impl<U: UserProvider + PackageProvider + Send + Sync + 'static> Handler<U> {
             dl: self.gitlab.cargo_dl_uri(scope, &token)?,
         })?);
 
+        debug!(?config_json,"packfile: config.json");
+
         // write config.json to the root of the repo
         packfile.insert(&[], "config.json", config_json)?;
 
@@ -331,6 +333,7 @@ impl<U: UserProvider + PackageProvider + Send + Sync + 'static> Handler<U> {
                 let meta = self
                     .fetch_metadata(crate_path, checksum, crate_name, version)
                     .await?;
+                trace!(?meta,"Retrieved metadata for {crate_name},{version}");
 
                 // each crates file in the index is a metadata blob for
                 // each version separated by a newline

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ use thrussh::{
 };
 use thrussh_keys::key::PublicKey;
 use tokio_util::{codec::Decoder, codec::Encoder as CodecEncoder};
-use tracing::{debug, error, info, info_span, instrument, Instrument, Span, trace};
+use tracing::{debug, error, info, info_span, instrument, Instrument, Span};
 use uuid::Uuid;
 
 const AGENT: &str = concat!(
@@ -333,7 +333,7 @@ impl<U: UserProvider + PackageProvider + Send + Sync + 'static> Handler<U> {
                 let meta = self
                     .fetch_metadata(crate_path, checksum, crate_name, version)
                     .await?;
-                trace!(?meta,"Retrieved metadata for {crate_name},{version}");
+                debug!(?meta,"Retrieved metadata for {crate_name},{version}");
 
                 // each crates file in the index is a metadata blob for
                 // each version separated by a newline
@@ -544,7 +544,6 @@ impl<U: UserProvider + PackageProvider + Send + Sync + 'static> thrussh::server:
         };
         // parses the given args in the same fashion as a POSIX shell
         let args = shlex::split(data);
-        debug!(parent:&self.span,?args,"Executing command");
         Box::pin(capture_errors(async move {
             // if the client didn't send `GIT_PROTOCOL=version=2` as an environment
             // variable when connecting, we'll just close the connection

--- a/src/providers/gitlab.rs
+++ b/src/providers/gitlab.rs
@@ -75,9 +75,9 @@ impl super::UserProvider for Gitlab {
                     .send()
                     .await?,
             )
-                .await?
-                .json()
-                .await?;
+            .await?
+            .json()
+            .await?;
 
             Ok(Some(User {
                 id: res.user.id,
@@ -122,9 +122,9 @@ impl super::UserProvider for Gitlab {
                 .send()
                 .await?,
         )
-            .await?
-            .json()
-            .await?;
+        .await?
+        .json()
+        .await?;
 
         Ok(impersonation_token.token)
     }

--- a/src/providers/gitlab.rs
+++ b/src/providers/gitlab.rs
@@ -31,7 +31,7 @@ impl Gitlab {
 
         let ssl_cert = match &config.ssl_cert {
             Some(cert_path) => {
-                let gitlab_cert_bytes = std::fs::read(&cert_path)?;
+                let gitlab_cert_bytes = std::fs::read(cert_path)?;
                 let gitlab_cert = Certificate::from_pem(&gitlab_cert_bytes)?;
                 client_builder = client_builder.add_root_certificate(gitlab_cert.clone());
                 Some(gitlab_cert)
@@ -65,7 +65,7 @@ impl super::UserProvider for Gitlab {
             // want to use our admin token for this request but still want to use any ssl cert provided.
             let mut client_builder = reqwest::Client::builder();
             if let Some(cert) = &self.ssl_cert {
-                client_builder = client_builder.add_root_certificate(cert.clone())
+                client_builder = client_builder.add_root_certificate(cert.clone());
             }
             let client = client_builder.build();
             let res: GitlabJobResponse = handle_error(

--- a/src/providers/gitlab.rs
+++ b/src/providers/gitlab.rs
@@ -75,9 +75,9 @@ impl super::UserProvider for Gitlab {
                     .send()
                     .await?,
             )
-            .await?
-            .json()
-            .await?;
+                .await?
+                .json()
+                .await?;
 
             Ok(Some(User {
                 id: res.user.id,
@@ -122,9 +122,9 @@ impl super::UserProvider for Gitlab {
                 .send()
                 .await?,
         )
-        .await?
-        .json()
-        .await?;
+            .await?
+            .json()
+            .await?;
 
         Ok(impersonation_token.token)
     }
@@ -155,8 +155,8 @@ impl super::PackageProvider for Gitlab {
         scope: Scope<'a>,
         do_as: &User,
     ) -> anyhow::Result<Vec<(Self::CratePath, Release)>>
-    where
-        Scope<'a>: 'async_trait,
+        where
+            Scope<'a>: 'async_trait,
     {
         let mut next_uri = Some({
             let mut uri = self.releases_uri(scope)?;
@@ -214,9 +214,9 @@ impl super::PackageProvider for Gitlab {
                                 .send()
                                 .await?,
                         )
-                        .await?
-                        .json()
-                        .await?;
+                            .await?
+                            .json()
+                            .await?;
 
                         let expected_file_name =
                             format!("{}-{}.crate", release.name, release.version);
@@ -237,7 +237,7 @@ impl super::PackageProvider for Gitlab {
                                 }),
                         )
                     }
-                    .instrument(info_span!("fetch_package_files")),
+                        .instrument(info_span!("fetch_package_files")),
                 ));
             }
         }
@@ -268,8 +268,16 @@ impl super::PackageProvider for Gitlab {
             Scope::Project(project) => self
                 .base_url
                 .join("projects/")?
-                .join(&format!("{}/", urlencoding::encode(project)))?,
-            Scope::Group(_) => self.base_url.join("projects/{crate}/")?,
+                .join(&format!("{}/", urlencoding::encode(project)))?
+                .to_string()
+            ,
+            Scope::Group(group) => self
+                .base_url
+                .join("projects/")?
+                .join(&urlencoding::encode(&format!("{group}/")))?
+                .to_string()
+                + "{crate}/"
+            ,
         };
         Ok(format!("{uri}packages/generic/{{crate}}/{{version}}/{{crate}}-{{version}}.crate?private_token={token}"))
     }

--- a/src/providers/gitlab.rs
+++ b/src/providers/gitlab.rs
@@ -9,7 +9,7 @@ use reqwest::{Certificate, header};
 use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, sync::Arc};
 use time::{Duration, OffsetDateTime};
-use tracing::{info, info_span, instrument, Instrument};
+use tracing::{info_span, instrument, Instrument};
 use url::Url;
 
 pub struct Gitlab {
@@ -30,7 +30,6 @@ impl Gitlab {
             .default_headers(headers);
 
         if let Some(cert_path) = &config.ssl_cert {
-            info!(cert_path,"loading gitlab certificate file");
             let gitlab_cert_bytes = std::fs::read(&cert_path)?;
             let gitlab_cert = Certificate::from_pem(&gitlab_cert_bytes)?;
             client_builder = client_builder.add_root_certificate(gitlab_cert);


### PR DESCRIPTION
Resolves #51 
This introduces the notion of 'scope' which is either 'Project' (default) or 'Group'

To pull dependencies from a group package manager, clients use an url with the following `cargo/config.toml` registries
```toml
[registries]
# Per-project registry:
# internal_project_registry = { index = "ssh://my.gitlab:2222/my_group/my_subgroup/my_project" } # per-project repo

# Per-group registry: set the path to the group path, add ?scope=group at the end
internal_group_registry = { index = "ssh://my.gitlab:222/my_group/my_subgroup/?scope=group" }
```

## Limitations
- The project name and the crate file _must_ match or this will fail on the client's side when performing the http fetch.
- Packages cannot be fetched for subgroups under the given group.
- Untested on multi-crates workspaces

This PR also filters packages by type so that only `generic` packages are being considered as some groups publish heterogenous packages (python / maven / generic)
