### PR TITLE
Make admin-token optional

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -13,4 +13,6 @@ uri = "http://127.0.0.1:3000"
 # users and create impersonation tokens. `sudo` is used to fetch all the
 # packages the user can access, and the impersonation token is returned
 # to the user to download packages
+#
+# May be omitted if clients are using their own personal access tokens.
 admin-token = "personal-access-token"

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,7 +33,8 @@ impl FromStr for Config {
 #[serde(rename_all = "kebab-case")]
 pub struct GitlabConfig {
     pub uri: Url,
-    pub admin_token: String,
+    /// If absent personal access tokens must be provided.
+    pub admin_token: Option<String>,
     #[serde(default = "GitlabConfig::default_token_expiry")]
     pub token_expiry: Duration,
     #[serde(default)]


### PR DESCRIPTION
With #53 merged this PR allows omitting the `admin-token` configuration, instead of having to set it as a dummy string.

@w4 would you like me to start a CHANGELOG.md?