### PR TITLE
Use thin lto and strip release binaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,7 @@ url = { version = "2.2", features = ["serde"] }
 urlencoding = "2.1"
 ustr = "0.10"
 uuid = { version = "1.1", features = ["v4"] }
+
+[profile.release]
+lto = "thin"
+strip = true


### PR DESCRIPTION
Simple profile.release config. Reduces binaries on Linux from 18MB -> 8.5MB, similarly reduces docker image size by ~10MB.