### PR TITLE
CI: fix fmt & remove actions-rs/cargo@v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,56 +7,48 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
+      - run: cargo check
 
   test:
     name: Test Suite
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
+      - run: cargo test
 
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
-      - run: rustup component add rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
+          components: rustfmt
+      - run: cargo fmt -- --check
 
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
-      - run: rustup component add clippy
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
+          components: clippy
+      - run: cargo clippy -- -D warnings

--- a/src/main.rs
+++ b/src/main.rs
@@ -411,7 +411,11 @@ impl<U: UserProvider + PackageProvider + Send + Sync + 'static> thrussh::server:
                     info!(
                         "Successfully authenticated for GitLab user `{}` by {}",
                         &user.username,
-                        if by_ssh_key { "SSH Key" } else { "Build or Personal Token" },
+                        if by_ssh_key {
+                            "SSH Key"
+                        } else {
+                            "Build or Personal Token"
+                        },
                     );
                     self.user = Some(Arc::new(user));
                     self.finished_auth(Auth::Accept).await


### PR DESCRIPTION
* Fix "Rustfmt" CI to actually check formatting `cargo fmt -- --check`. (Source changes are just from running `cargo fmt`).
* Remove actions-rs/cargo@v1 use, upstream has been archived and isn't necessary here.
* Set "Clippy" CI to fail on warnings.