### PR TITLE
Re-use single http client / connection pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1182,9 +1182,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.75"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "907a61bd0f64c2f29cd1cf1dc34d05176426a3f504a78010f08416ddb7b13708"
+checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
 dependencies = [
  "unicode-ident",
 ]
@@ -1423,18 +1423,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.194"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b114498256798c94a0689e1a15fec6005dee8ac1f41de56404b67afc2a4b773"
+checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.194"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3385e45322e8f9931410f01b3031ec534c3947d0e94c18049af4d9f9907d4e0"
+checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/main.rs
+++ b/src/main.rs
@@ -232,7 +232,7 @@ impl<U: UserProvider + PackageProvider + Send + Sync + 'static> Handler<U> {
         checksum: &str,
         crate_name: &str,
         crate_version: &str,
-        do_as: &User,
+        do_as: &Arc<User>,
     ) -> anyhow::Result<Arc<CargoIndexCrateMetadata>> {
         let key = MetadataCacheKey {
             checksum: checksum.into(),

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -24,14 +24,14 @@ pub trait PackageProvider {
     async fn fetch_releases_for_project(
         self: Arc<Self>,
         project: &str,
-        do_as: &User,
+        do_as: &Arc<User>,
     ) -> anyhow::Result<Vec<(Self::CratePath, Release)>>;
 
     async fn fetch_metadata_for_release(
         &self,
         path: &Self::CratePath,
         version: &str,
-        do_as: &User,
+        do_as: &Arc<User>,
     ) -> anyhow::Result<cargo_metadata::Metadata>;
 
     fn cargo_dl_uri(&self, project: &str, token: &str) -> anyhow::Result<String>;


### PR DESCRIPTION
For personal access token use, current code builds a new `reqwest::Client` for each http call. This prevents connection pooling, so this PR switches to use a single `Client` and set headers on requests when necessary.

After testing it fetch latencies were unchanged, I guess connection pooling isn't a problem for this use case? 

I think it's probably still worth merging as, imo, the code is cleaner this way.