### PR TITLE
Fix cache-releases-older-than support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Add info logs for release & metadata fetch latency.
 - When fetching all releases handle 429 by backing off.
 - Improve fetch error logging.
-- Added crate eligibility cache.
+- Added crate eligibility cache. May be controlled with config `cache-releases-older-than`.
 - Introduce configurable cache backend with a RocksDB implementation (set `cache.type = "rocksdb"` and `cache.path = "cache"` to use it), defaults to `cache.type = "in-memory"`.
 - Support crate yanking by creating a `yanked` file on the release.
 - Add `bust-cache` command, invoked via `ssh [registry] -- bust-cache [project] [crate-name] [crate-version]` to remove eligibility cache (ie. after a crate has been yanked)

--- a/config.toml
+++ b/config.toml
@@ -26,7 +26,7 @@ uri = "http://127.0.0.1:3000"
 
 ## Cache file checksum fetches for all release older than this value.
 ##
-## If omitted no caching will occur.
+## If omitted will cache all releases of all ages.
 ##
 ## Note: Caching shouldn't be used if published releases are expected to be mutated.
 ## However, a grace period can allow the majority of crates to benefit from caching

--- a/src/config.rs
+++ b/src/config.rs
@@ -55,8 +55,10 @@ pub struct GitlabConfig {
     #[serde(default)]
     pub metadata_format: MetadataFormat,
     /// Cache file checksum fetches for all release older than this value.
+    ///
+    /// Default zero (cache all releases).
     #[serde(default, with = "humantime_serde")]
-    pub cache_releases_older_than: Option<Duration>,
+    pub cache_releases_older_than: Duration,
 }
 
 impl GitlabConfig {
@@ -135,6 +137,6 @@ fn deser_config() {
     assert_eq!(gitlab.metadata_format, MetadataFormat::JsonZst);
     assert_eq!(
         gitlab.cache_releases_older_than,
-        Some(Duration::from_secs(2 * 24 * 60 * 60))
+        Duration::from_secs(2 * 24 * 60 * 60)
     );
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -251,7 +251,7 @@ impl<U: UserProvider + PackageProvider + Send + Sync + 'static> Handler<U> {
             return Ok(cache);
         }
 
-        info!("Fetching metadata from GitLab");
+        debug!("Fetching metadata from GitLab");
 
         // fetch metadata from the provider
         let metadata = gitlab


### PR DESCRIPTION
Relates to https://github.com/w4/gitlab-cargo-shim/issues/81#issuecomment-1966565964

Also make default `cache_releases_older_than` value **zero** so all releases are cached.

I also moved some info logs to debug.